### PR TITLE
Specify encoding on all opens

### DIFF
--- a/mcu_calendar/events.py
+++ b/mcu_calendar/events.py
@@ -67,7 +67,7 @@ class Movie(GoogleMediaEvent):
         """
         Factory method to create a Movie object from yaml
         """
-        with open(yaml_path, 'r') as yaml_file:
+        with open(yaml_path, 'r', encoding='UTF-8') as yaml_file:
             yaml_data = yaml.load(yaml_file, Loader=yaml.Loader)
         return Movie(**yaml_data)
 
@@ -111,7 +111,7 @@ class Show(GoogleMediaEvent):
         """
         Factory method to create a Show object from yaml
         """
-        with open(yaml_path, 'r') as yaml_file:
+        with open(yaml_path, 'r', encoding='UTF-8') as yaml_file:
             yaml_data = yaml.load(yaml_file, Loader=yaml.Loader)
         return Show(**yaml_data)
 

--- a/mcu_calendar/google_service_helper.py
+++ b/mcu_calendar/google_service_helper.py
@@ -14,7 +14,7 @@ def update_creds_token(creds):
     Updates the token.json containing the login token so that when testing
     it is not required to login constantly
     """
-    with open('token.json', 'w') as token:
+    with open('token.json', 'w', encoding='UTF-8') as token:
         token.write(creds.to_json())
 
 

--- a/mcu_calendar/main.py
+++ b/mcu_calendar/main.py
@@ -20,7 +20,7 @@ def get_cal_id():
     2. From GOOGLE_MCU_CALENDAR_ID environment variable
     """
     if os.path.exists('cal_id.txt'):
-        with open('cal_id.txt', 'r') as reader:
+        with open('cal_id.txt', 'r', encoding='UTF-8') as reader:
             return reader.read().strip()
     if 'GOOGLE_MCU_CALENDAR_ID' in os.environ:
         return os.environ['GOOGLE_MCU_CALENDAR_ID']


### PR DESCRIPTION
It seems like pylint has updated with some new rules.  It now is failing because of open being called without specifying an encoding.