### PR TITLE
Handle renames better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ run:
 	$(info ************  Running        ************)
 	@python main.py
 
+webscrape:
+	$(info )
+	$(info ************  Running        ************)
+	@python get_new_media.py
+
 force:
 	$(info )
 	$(info ************  Running(force) ************)

--- a/data/mcu-adjacent-movies/kraven_the_hunter.yaml
+++ b/data/mcu-adjacent-movies/kraven_the_hunter.yaml
@@ -1,4 +1,5 @@
 title: Kraven the Hunter
 release_date: 2024-12-13
+imdb_id: tt8790086
 description: |
   https://www.imdb.com/title/tt8790086

--- a/data/mcu-adjacent-movies/the_spider_within.yaml
+++ b/data/mcu-adjacent-movies/the_spider_within.yaml
@@ -1,4 +1,0 @@
-title: The Spider Within
-release_date: 2023-06-11
-description: |
-  https://www.imdb.com/title/None

--- a/data/mcu-movies/avengers_doomsday.yaml
+++ b/data/mcu-movies/avengers_doomsday.yaml
@@ -1,5 +1,0 @@
-title: 'Avengers: Doomsday'
-release_date: 2026-05-01
-description: |
-  https://www.imdb.com/title/tt21357150
-  https://www.marvel.com/movies/avengers-doomsday

--- a/data/mcu-movies/avengers_secret_wars.yaml
+++ b/data/mcu-movies/avengers_secret_wars.yaml
@@ -1,5 +1,6 @@
 title: 'Avengers: Secret Wars'
 release_date: 2027-05-07
+imdb_id: tt21361444
 description: |
   https://www.imdb.com/title/tt21361444
   https://www.marvel.com/movies/avengers-secret-wars

--- a/data/mcu-movies/avengers_the_kang_dynasty.yaml
+++ b/data/mcu-movies/avengers_the_kang_dynasty.yaml
@@ -1,5 +1,0 @@
-title: 'Avengers: The Kang Dynasty'
-release_date: 2026-05-01
-description: |
-  https://www.imdb.com/title/tt21357150
-  https://www.marvel.com/movies/avengers-kang-dynasty

--- a/data/mcu-movies/captain_america_brave_new_world.yaml
+++ b/data/mcu-movies/captain_america_brave_new_world.yaml
@@ -1,5 +1,6 @@
 title: 'Captain America: Brave New World'
 release_date: 2025-02-14
+imdb_id: tt14513804
 description: |
   https://www.imdb.com/title/tt14513804
   https://www.marvel.com/movies/captain-america-brave-new-world

--- a/data/mcu-movies/spider_man_4.yaml
+++ b/data/mcu-movies/spider_man_4.yaml
@@ -1,4 +1,5 @@
 title: Spider-Man 4
 release_date: 2026-07-24
+imdb_id: tt22084616
 description: |
-  https://www.imdb.com/title/tt28491417
+  https://www.imdb.com/title/tt22084616

--- a/data/mcu-movies/the_fantastic_four.yaml
+++ b/data/mcu-movies/the_fantastic_four.yaml
@@ -1,4 +1,0 @@
-title: The Fantastic Four
-release_date: 2025-07-25
-description: |
-  https://www.imdb.com/title/tt10676052

--- a/data/mcu-movies/the_fantastic_four_first_steps.yaml
+++ b/data/mcu-movies/the_fantastic_four_first_steps.yaml
@@ -1,5 +1,0 @@
-title: 'The Fantastic Four: First Steps'
-release_date: 2025-07-25
-description: |
-  https://www.imdb.com/title/tt10676052
-  https://www.marvel.com/movies/the-fantastic-four-first-steps

--- a/data/mcu-movies/thor_5.yaml
+++ b/data/mcu-movies/thor_5.yaml
@@ -1,4 +1,0 @@
-title: Thor 5
-release_date: 2026-11-06
-description: |
-  https://www.imdb.com/title/None

--- a/data/mcu-movies/thunderbolts.yaml
+++ b/data/mcu-movies/thunderbolts.yaml
@@ -1,4 +1,5 @@
 title: Thunderbolts*
 release_date: 2025-05-02
+imdb_id: tt20969586
 description: |
   https://www.imdb.com/title/tt20969586

--- a/data/mcu-shows/daredevil_born_again.yaml
+++ b/data/mcu-shows/daredevil_born_again.yaml
@@ -9,6 +9,7 @@ release_dates:
 - 2025-04-15
 - 2025-04-22
 - 2025-04-29
+imdb_id: tt18923754
 description: |
   https://www.imdb.com/title/tt18923754
   https://www.marvel.com/tv-shows/daredevil-born-again/1

--- a/data/mcu-shows/eyes_of_wakanda.yaml
+++ b/data/mcu-shows/eyes_of_wakanda.yaml
@@ -1,5 +1,6 @@
 title: Eyes of Wakanda
 release_dates:
 - 2025-08-06
+imdb_id: tt13968252
 description: |
   https://www.imdb.com/title/tt13968252

--- a/data/mcu-shows/ironheart.yaml
+++ b/data/mcu-shows/ironheart.yaml
@@ -6,6 +6,7 @@ release_dates:
 - 2025-07-15
 - 2025-07-22
 - 2025-07-29
+imdb_id: tt13623126
 description: |
   https://www.imdb.com/title/tt13623126
   https://www.marvel.com/tv-shows/ironheart/1

--- a/data/mcu-shows/what_if_3.yaml
+++ b/data/mcu-shows/what_if_3.yaml
@@ -9,6 +9,7 @@ release_dates:
 - 2024-12-28
 - 2024-12-29
 - 2024-12-30
+imdb_id: tt10168312
 description: |
   https://www.imdb.com/title/tt10168312
   https://www.marvel.com/tv-shows/animation/what-if/1

--- a/data/mcu-shows/your_friendly_neighborhood_spider_man.yaml
+++ b/data/mcu-shows/your_friendly_neighborhood_spider_man.yaml
@@ -1,6 +1,7 @@
 title: Your Friendly Neighborhood Spider-Man
 release_dates:
 - 2025-01-29
+imdb_id: tt16027074
 description: |
   https://www.imdb.com/title/tt16027074
   https://www.marvel.com/tv-shows/your-friendly-neighborhood-spider-man/1

--- a/mcu_calendar/events.py
+++ b/mcu_calendar/events.py
@@ -19,7 +19,8 @@ class GoogleMediaEvent(ABC):
     Base class for a google event that is defined in yaml
     """
 
-    def __init__(self, title: str, description: str) -> None:
+    # pylint: disable=unused-argument
+    def __init__(self, title: str, description: str, **kwargs: dict) -> None:
         self.title = title
         self.description = description
 
@@ -79,8 +80,8 @@ class Movie(GoogleMediaEvent):
     The event that describes a movie release date
     """
 
-    def __init__(self, title: str, description: str, release_date: date) -> None:
-        super().__init__(title, description)
+    def __init__(self, title: str, description: str, release_date: date, **kwargs: dict) -> None:
+        super().__init__(title, description, **kwargs)
         self.release_date = release_date
 
     @staticmethod
@@ -121,8 +122,8 @@ class Show(GoogleMediaEvent):
     The event that describes a show start date and how many weeks it runs for
     """
 
-    def __init__(self, title: str, release_dates: List[date], description: str) -> None:
-        super().__init__(title, description)
+    def __init__(self, title: str, release_dates: List[date], description: str, **kwargs: dict) -> None:
+        super().__init__(title, description, **kwargs)
         self.release_dates = release_dates
         self.start_date = release_dates[0]
 

--- a/mcu_calendar/events.py
+++ b/mcu_calendar/events.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import date, timedelta
 from pathlib import Path
+from re import search as re_search
 from typing import Any, Dict, List
 
 import yaml
@@ -19,10 +20,16 @@ class GoogleMediaEvent(ABC):
     Base class for a google event that is defined in yaml
     """
 
-    # pylint: disable=unused-argument
-    def __init__(self, title: str, description: str, **kwargs: dict) -> None:
+    def __init__(self, title: str, description: str, file_path: Path, imdb_id: str | None) -> None:
         self.title = title
         self.description = description
+        self.imdb_id = imdb_id
+        self.file_path = file_path
+
+        if not self.imdb_id:
+            matches = re_search("https://www.imdb.com/title/(.*)", self.description)
+            if matches:
+                self.imdb_id = matches.group(1)
 
     def to_google_event(self) -> Dict[str, Any]:
         """
@@ -80,8 +87,11 @@ class Movie(GoogleMediaEvent):
     The event that describes a movie release date
     """
 
-    def __init__(self, title: str, description: str, release_date: date, **kwargs: dict) -> None:
-        super().__init__(title, description, **kwargs)
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self, title: str, description: str, release_date: date, file_path: Path, imdb_id: str | None = None
+    ) -> None:
+        super().__init__(title, description, file_path, imdb_id)
         self.release_date = release_date
 
     @staticmethod
@@ -90,7 +100,7 @@ class Movie(GoogleMediaEvent):
         Factory method to create a Movie object from yaml
         """
         yaml_data = GoogleMediaEvent.load_yaml(yaml_path)
-        return Movie(**yaml_data)
+        return Movie(**yaml_data, file_path=yaml_path)
 
     def _to_google_event_core(self) -> Dict[str, Any]:
         return {
@@ -122,8 +132,11 @@ class Show(GoogleMediaEvent):
     The event that describes a show start date and how many weeks it runs for
     """
 
-    def __init__(self, title: str, release_dates: List[date], description: str, **kwargs: dict) -> None:
-        super().__init__(title, description, **kwargs)
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self, title: str, release_dates: List[date], description: str, file_path: Path, imdb_id: str | None = None
+    ) -> None:
+        super().__init__(title, description, file_path, imdb_id)
         self.release_dates = release_dates
         self.start_date = release_dates[0]
 
@@ -133,7 +146,7 @@ class Show(GoogleMediaEvent):
         Factory method to create a Show object from yaml
         """
         yaml_data = GoogleMediaEvent.load_yaml(yaml_path)
-        return Show(**yaml_data)
+        return Show(**yaml_data, file_path=yaml_path)
 
     def _rfc5545_weekday(self) -> str:
         _recurrence_weekday = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"]

--- a/mcu_calendar/webscraping.py
+++ b/mcu_calendar/webscraping.py
@@ -234,6 +234,9 @@ def __get_search_link(name: str, search_id: str, query: str) -> Optional[str]:
     """
     Gets the first link for the query with a title that matches the given name
     """
+    if "GOOGLE_SEARCH_API_KEY" not in os.environ:
+        return None
+
     result = requests.get(
         GOOGLE_SEARCH_FOMRAT.format(
             api_key=os.environ["GOOGLE_SEARCH_API_KEY"],

--- a/mcu_calendar/yamlcalendar.py
+++ b/mcu_calendar/yamlcalendar.py
@@ -39,14 +39,14 @@ class YamlCalendar:
         return [factory(f) for f in folder.iterdir()]
 
     @staticmethod
-    def _get_movies(folder: Path) -> Sequence[Movie]:
+    def get_movies(folder: Path) -> Sequence[Movie]:
         """
         Gets all Movie objects defined in the yaml files in ./data/movies
         """
         return YamlCalendar._get_objects_from_data(folder, Movie.from_yaml)
 
     @staticmethod
-    def _get_shows(folder: Path) -> Sequence[Show]:
+    def get_shows(folder: Path) -> Sequence[Show]:
         """
         Gets all Show objects defined in the yaml files in ./data/shows
         """
@@ -97,8 +97,8 @@ class YamlCalendar:
         """
         print("    UPDATING", self.name)
         cur_events = self._get_google_events()
-        movies = [m for mdir in self.movie_dirs for m in YamlCalendar._get_movies(mdir)]
-        shows = [s for sdir in self.show_dirs for s in YamlCalendar._get_shows(sdir)]
+        movies = [m for mdir in self.movie_dirs for m in YamlCalendar.get_movies(mdir)]
+        shows = [s for sdir in self.show_dirs for s in YamlCalendar.get_shows(sdir)]
         self._create_google_event("[bold]Movies..", movies, cur_events, force=force)
         self._create_google_event("[bold]Shows...", shows, cur_events, force=force)
 


### PR DESCRIPTION
Fixes the issue where a renamed movie will leave the old movie on the calendar.  
This looks at the IMDB ID to verify that the movie is the same.  Completely removed movies will still need to me removed manually